### PR TITLE
Add newsletter signup button to PHP Roundup #1 post, plus the initial layout

### DIFF
--- a/source/_layouts/newsletter.html
+++ b/source/_layouts/newsletter.html
@@ -1,0 +1,11 @@
+<div class="px-4 pt-3 pb-10 mb-6 border-b border-t -mx-4 border-gray-200">
+    <div class="max-w-xl mx-auto">
+        <h2 class="text-xl text-left inline-block font-semibold text-gray-800 mb-1">Subscribe to PHP Foundation Updates</h2>
+        <form method="POST" action="https://php-foundation-mailcoach.com/subscribe/9be4e2bd-f9d8-475c-b00e-2dcc4cf90056" class="mt-2">
+            <div class="flex items-center">
+                <input placeholder="Your email address" type="email" class="w-full px-2 py-4 mr-2  bg-gray-100 shadow-inner rounded-md border border-gray-400 focus:outline-none" name="email" required>
+                <button class="bg-[#7f52ff] text-gray-200 px-5 py-2 rounded shadow " style="margin-left: -7.8rem;">Sign Up</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/source/_posts/2022-04-28-php-roundup-1.md
+++ b/source/_posts/2022-04-28-php-roundup-1.md
@@ -16,13 +16,18 @@ In this series, we highlight some of the interesting and major improvements made
 
 You don’t necessarily have to be a PHP Foundation backer to follow the PHP Roundup. We’ll be publishing the posts on our website, and you can subscribe to a newsletter:
 
-<form method="POST" action="https://php-foundation-mailcoach.com/subscribe/9be4e2bd-f9d8-475c-b00e-2dcc4cf90056" class="mb-8 flex justify-center items-center h-screen">
-    <div>
-        <label for="email" >Email</label>
-        <input type=email name="email" class="form-inp">
-        <button type="submit" class="form-btn">Subscribe</button>
+
+<div class="px-4 pt-3 pb-10 mb-6 border-b border-t -mx-4 border-gray-200">
+    <div class="max-w-xl mx-auto">
+        <h2 class="text-xl text-left inline-block font-semibold text-gray-800 mb-1">Subscribe to PHP Foundation Updates</h2>
+        <form method="POST" action="https://php-foundation-mailcoach.com/subscribe/9be4e2bd-f9d8-475c-b00e-2dcc4cf90056" class="mt-2">
+            <div class="flex items-center">
+                <input placeholder="Your email address" type="email" class="w-full px-2 py-4 mr-2  bg-gray-100 shadow-inner rounded-md border border-gray-400 focus:outline-none" name="email" required>
+                <button class="bg-[#7f52ff] text-gray-200 px-5 py-2 rounded shadow " style="margin-left: -7.8rem;">Sign Up</button>
+            </div>
+        </form>
     </div>
-</form>
+</div>
 
 
 The PHP Foundation currently supports six part-time PHP contributors who work on both maintenance and new features for PHP. Maintenance is not limited to fixing bugs, but also includes work to reduce technical debt, making life easier for everyone working on PHP. The contributors funded by the PHP Foundation collaborate with other contributors on code, documentation, and discussions.


### PR DESCRIPTION
Added the initial newsletter signup form to the post, plus the layout to `source/_layout` directory. Ideally, we should be able to simply _include_ that layout from any markdown file, but I have yet to figure out how. For the time being I copy-pasta'd the newsletter form to the markdown file. 

![image](https://user-images.githubusercontent.com/811553/165738013-4dab9f07-b2d9-47b0-be8a-4c6284ad21de.png)
