### PR TITLE
Fix nav links title

### DIFF
--- a/source/_views/post.html
+++ b/source/_views/post.html
@@ -26,10 +26,10 @@
         <nav class="flex flex-row items-center justify-center mt-4 article">
             <ul class="list-none">
                 {% if page.next_post %}
-                    <li>Next: <a class="next" href="{{ site.url }}{{ page.next_post.url }}" title="{{ page.next_post.title }}"><span class="title">{{ page.next_post.title }}</span></a></li>
+                    <li>Next: <a class="next" href="{{ site.url }}{{ page.next_post.url }}" title="{{ page.next_post.title|raw }}"><span class="title">{{ page.next_post.title|raw }}</span></a></li>
                 {% endif %}
                 {% if page.previous_post %}
-                    <li>Previous: <a class="previous" href="{{ site.url }}{{ page.previous_post.url }}" title="{{ page.previous_post.title }}"><span class="title">{{ page.previous_post.title }}</span></a></li>
+                    <li>Previous: <a class="previous" href="{{ site.url }}{{ page.previous_post.url }}" title="{{ page.previous_post.title|raw }}"><span class="title">{{ page.previous_post.title|raw }}</span></a></li>
                 {% endif %}
             </ul>
         </nav>


### PR DESCRIPTION
Use a `raw` filter to correctly display a title containing special characters.

<details>
  <summary>Example</summary>
  
![image](https://user-images.githubusercontent.com/4685504/165741565-0f8a503b-aeac-4742-8805-4edcabfcd26c.png)
</details>
