### PR TITLE
Fix `title` tag

### DIFF
--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>{% block title %}{{ page.title }}{% endblock %} &mdash; {{ site.title }} &mdash; {{ site.subtitle }}</title>
+    <title>{% block title %}{{ page.title|raw }}{% endblock %} &mdash; {{ site.title }} &mdash; {{ site.subtitle }}</title>
     <meta charset="utf-8">
     <meta name="theme-color" content="#ffffff">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
Yet another place =)

Use a `raw` filter to correctly display a title containing special characters.