### PR TITLE
Show Blog link for mobile

### DIFF
--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -67,7 +67,7 @@
             </div>
 
            <div class="header-group flex items-center">
-                <div class="hidden lg:block text-base">
+                <div class="text-base">
                     <a class="text-[rgba(25,25,28,.7)] mr-4"
                        href="{{ site.url }}/blog">
                        Blog


### PR DESCRIPTION
Small PR, but it hopefully fixes https://github.com/ThePHPF/thephp.foundation/issues/15 
Blog link should fit well even on mobile without any additional changes to layout
