### PR TITLE
Better mobile styles, Tailwind cleanup

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,140 +1,125 @@
 @tailwind base;
-
-p, ol, ul {
-  @apply pb-8;
-}
-
-p, li {
-	@apply font-normal text-zinc-800 text-base leading-relaxed;
-}
-
-a {
-  @apply text-blue-500 underline
-}
-
-
-a:hover, a:visited:hover {
-  @apply text-zinc-400;
-}
-
-/*a:visited {*/
-/*  @apply text-purple-500;*/
-/*}*/
-
-.form-inp, .form-btn {
-	@apply border border-slate-300 hover:border-indigo-300;
-}
-
-.form-btn {
-	@apply pl-4 pr-4 rounded;
-}
-
-h1, h2, h3, h4 {
-	@apply mb-6 mt-6 text-zinc-800;
-}
-
-h1 {
-  @apply leading-tight font-bold text-4xl;
-}
-
-h2 {
-  @apply font-bold text-3xl;
-}
-
-h3 {
-  @apply font-bold text-2xl;
-}
-
-h4 {
-  @apply font-bold text-xl;
-}
-
-ul {
-  @apply list-disc list-outside mb-4 ml-5;
-}
-
-ol {
-  @apply list-decimal list-outside mb-4 ml-5;
-}
-
-blockquote {
-	@apply bg-yellow-50 ;
-}
-
-blockquote p {
-	@apply p-4 pl-8;
-}
-
 @tailwind components;
 @tailwind utilities;
 
-body {
-	font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
-    /*font-family: "Inter",system-ui,-apple-system,BlinkMacSystemFont,*/
-    /*"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Droid Sans","Helvetica Neue",Arial,sans-serif;*/
-    box-sizing: border-box;
-	@apply text-zinc-600;
+@layer base {
+    body {
+        @apply font-sans text-zinc-600 box-border;
+    }
+
+    h1, h2, h3, h4 {
+        @apply mb-6 mt-6 text-zinc-800;
+    }
+
+    h1 {
+        @apply leading-tight font-bold text-4xl;
+    }
+
+    h2 {
+        @apply font-bold text-3xl;
+    }
+
+    h3 {
+        @apply font-bold text-2xl;
+    }
+
+    h4 {
+        @apply font-bold text-xl;
+    }
+
+    p, ol, ul {
+        @apply pb-8;
+    }
+
+    p, li {
+        @apply font-normal text-zinc-800 text-base leading-relaxed;
+    }
+
+    ul {
+        @apply list-disc list-outside mb-4 ml-5;
+    }
+
+    ol {
+        @apply list-decimal list-outside mb-4 ml-5;
+    }
+
+    blockquote {
+        @apply bg-yellow-50 ;
+    }
+
+    blockquote p {
+        @apply p-4 pl-8;
+    }
+
+    a {
+        @apply text-blue-500 underline
+    }
+
+    a:hover, a:visited:hover {
+        @apply text-zinc-400;
+    }
 }
 
-.li-item:not(:last-child) {
-    margin-right: 32px;
-}
+@layer components {
+    .btn-foundation {
+        @apply lg:pl-[calc(25% + 16px)];
+    }
 
-.group-link {
-    color: rgba(39, 40, 44, .7);
-}
+    .form-inp, .form-btn {
+        @apply border border-slate-300 hover:border-indigo-300;
+    }
 
-.group-link:hover {
-    color: #27282c;
-}
+    .form-btn {
+        @apply pl-4 pr-4 rounded;
+    }
 
-.btn {
-    color: rgba(25, 25, 28, .7);
-    font-size: 16px;
-    letter-spacing: .0015em;
-    line-height: 24px;
-}
 
-.nav-org {
-    color: rgba(25,25,28,.7);
-}
+    .li-item {
+        @apply mr-8 last:mr-0;
+    }
 
-.nav-org:hover {
-    color: #19191c;
-    border-bottom: 1px solid #19191c;
-    text-decoration: none;
-}
+    .group-link {
+        @apply text-slate-700/70;
+    }
 
-.nav-org:after {
-    content: "\2197";
-    margin-left: 0.15em;
-    margin-right: 0.15em;
-    transition: margin-right .3s,margin-left .3s;
-}
+    .group-link:hover {
+        @apply text-slate-700;
+    }
 
-.nav-org:hover:after {
-    color: #19191c;
-    margin-left: .3em;
-    margin-right: 0;
-}
+    .btn {
+        @apply text-slate-900/70 text-base tracking-tighter leading-6;
+    }
 
-.footer-li:after {
-    border-right: 1px solid rgba(255, 255, 255, 0.5);;
-    content: "";
-    display: inline-block;
-    height: .75em;
-    margin: 0 1ex;
-    width: 0
-}
+    .nav-org {
+        @apply text-slate-900/70 hover:text-slate-900 hover:border-b hover:border-solid hover:border-slate-900 hover:no-underline after:content-["\2197"] after:mx-0.5 after:duration-300 hover:after:text-slate-900 hover:after:ml-1 hover:after:mr-0;
+    }
 
-.footer-li:last-of-type:after {
-    display: none
+    .footer-li {
+        @apply after:border-r after:border-solid after:border-white/50 after:content-[""] after:inline-block after:h-3 after:my-0 after:mx-4 after:w-0 last-of-type:after:hidden;
+    }
+
+    .index-module {
+        @apply relative rounded-lg overflow-hidden md:rounded-2xl;
+    }
+
+    .button-prev {
+        @apply absolute right-9 rounded;
+    }
+
+    .button-prev:hover {
+        @apply bg-slate-900 opacity-10 text-slate-900
+    }
+
+    .button-next {
+        @apply absolute right-0 rounded-lg;
+    }
+
+    .button-next:hover {
+        @apply bg-slate-900 opacity-10 text-slate-900
+    }
 }
 
 .footer-link {
-    border-bottom: 0 transparent;
-    color: rgba(255, 255, 255, 0.7);
-    text-decoration: none;
     background-image: linear-gradient(180deg, #fff 100%, transparent 0);
     background-size: auto 0;
     background-repeat: repeat-x;
@@ -143,60 +128,4 @@ body {
 
 .footer-link:hover {
     background-size: auto calc(100% + 4px);
-    color: #19191c;
-    text-decoration: none;
-}
-
-@media (min-width: 1024px) {
-    .btn-foundation {
-        padding-left: calc(25% + 16px);
-    }
-}
-
-@supports (-webkit-background-clip:text) {
-    .background-li {
-        -webkit-text-fill-color: transparent;
-        background: radial-gradient(89.53% 145.96% at .34% 100.79%,
-            #ef4857 0, #de4970 17.58%, #b44db0 50.31%, #7f52ff 97.03%);
-        -webkit-background-clip: text
-    }
-}
-
-.contacts-bg {
-    background: radial-gradient(89.53% 145.96% at .34% 100.79%,
-        #ef4857 0, #de4970 17.58%, #b44db0 50.31%, #7f52ff 97.03%)
-}
-
-.index-module {
-    border-radius: 8px;
-    overflow: hidden;
-    position: relative;
-}
-
-@media (min-width: 768px) {
-    .index-module {
-        border-radius: 16px;
-    }
-}
-
-.button-prev {
-    position: absolute;
-    right: 38px;
-    border-radius: 4px;
-}
-
-.button-prev:hover {
-    background: rgba(25,25,28,.1);
-    color: #19191c !important;
-}
-
-.button-next {
-    position: absolute;
-    right: 0;
-    border-radius: 4px;
-}
-
-.button-next:hover {
-    background: rgba(25,25,28,.1);
-    color: #19191c;
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -7,6 +7,10 @@
         @apply font-sans text-zinc-600 box-border;
     }
 
+    html {
+        @apply min-h-screen;
+    }
+
     h1, h2, h3, h4 {
         @apply mb-6 mt-6 text-zinc-800;
     }

--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -86,8 +86,8 @@
 
     {%block content_wrapper %}{% block content %}{% endblock %}{% endblock %}
 
-    <footer class="bg-[#27282c] py-8 px-4 md:flex items-center justify-between">
-        <ul class="flex flex-wrap list-none mb-6 text-[#27282c] text-base font-normal items-center md:mb-0">
+    <footer class="py-8 px-4 md:flex md:items-center md:justify-between bg-[#27282c]">
+        <ul class="mb-6 md:mb-0 flex flex-wrap items-center list-none text-[#27282c] text-base font-normal">
             <li class="footer-li">
                 <a href="{{ site.url }}/code-of-conduct"
                     class="footer-link text-white/30 hover:text-slate-900 no-underline hover:no-underline border-b-0 border-transparent">
@@ -109,7 +109,7 @@
             </li>
         </ul>
 
-        <p class="font-normal flex items-center footer-link text-white/30 hover:text-slate-900 no-underline hover:no-underline border-b-0 border-transparent">
+        <p class="font-normal text-center sm:flex sm:items-center footer-link text-white/30 hover:text-slate-900 no-underline hover:no-underline border-b-0 border-transparent">
             &copy; The PHP Foundation
         </p>
     </footer>

--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -90,26 +90,26 @@
         <ul class="flex flex-wrap list-none mb-6 text-[#27282c] text-base font-normal items-center md:mb-0">
             <li class="footer-li">
                 <a href="{{ site.url }}/code-of-conduct"
-                    class="text-[rgba(39, 40, 44, .7)] footer-link hover:text-[#27282c]">
+                    class="footer-link text-white/30 hover:text-slate-900 no-underline hover:no-underline border-b-0 border-transparent">
                     Code of Conduct
                 </a>
             </li>
 
             <li class="footer-li lg:hidden">
                 <a href="{{ site.url }}/blog"
-                    class="text-[rgba(39, 40, 44, .7)] footer-link hover:text-[#27282c]">
+                    class="footer-link text-white/30 hover:text-slate-900 no-underline hover:no-underline border-b-0 border-transparent">
                     Blog
                 </a>
             </li>
 
             <li class="footer-li">
-                <a href="https://twitter.com/thephpf" class="group-link footer-link">
+                <a href="https://twitter.com/thephpf" class="group-link footer-link text-white/30 hover:text-slate-900 no-underline hover:no-underline border-b-0 border-transparent">
                     Twitter
                 </a>
             </li>
         </ul>
 
-        <p class="font-normal flex items-center footer-link">
+        <p class="font-normal flex items-center footer-link text-white/30 hover:text-slate-900 no-underline hover:no-underline border-b-0 border-transparent">
             &copy; The PHP Foundation
         </p>
     </footer>

--- a/source/index.html
+++ b/source/index.html
@@ -3,11 +3,10 @@ layout: default
 title: The PHP Foundation
 ---
 
-<main class="flex flex-col bg-[#f4f4f4] min-w-[320px] min-h-[100vh] w-full">
-<section class="bg-white">
-    <!-- <div class="overflow-hidden mx-auto max-w-full px-4 box-border lg:relative xl:px-8 xl:max-w-[1480px]"> -->
-    <div class="m-auto max-w-7xl px-4 xl:px-8 md:my-8 flex flex-row content-start items-stretch">
-        <div class="flex-auto max-w48 w-48 justify-center">
+<main class="flex flex-col bg-[#f4f4f4] min-w-[320px] w-full">
+<section class="max-w-full bg-white">
+    <div class="max-w-[1480px] mx-auto md:my-8 px-4 xl:px-8 flex flex-row content-start items-stretch">
+        <div class="flex-auto w-48 justify-center">
             <h1 class="text-[#27282c] font-normal tracking-[-1px] leading-[3rem] mt-16
                 xl:tracking-[-3px] xl:text-[4rem] xl:leading-[5.5rem] mr-24 ">
                 We&nbsp;support, advance,
@@ -15,7 +14,8 @@ title: The PHP Foundation
 				the&nbsp;PHP&nbsp;Language
             </h1>
         </div>
-		<div class="flex-auto max-w64 w-8" >
+
+		<div class="flex-auto w-8" >
 			<a href="https://opencollective.com/phpfoundation">
 				<picture class="mt-24">
 					<img class="w-full" src="/assets/icons/php_foundation.svg" alt="The PHP Foundation"/>
@@ -25,84 +25,84 @@ title: The PHP Foundation
     </div>
 </section>
 
-<section class="box-border sm:mt-24 m-auto max-w-full px-4 xl:max-w-[1480px] xl:px-8 md:my-8">
-	<div class="m-auto max-w-7xl px-4 xl:px-8 md:my-8 flex flex-col sm:flex-row content-start items-stretch">
-		<h2 class="w-full sm:mr-4 bg-slate-700 text-white p-4 w-64">What is the foundation</h2>
+<section class="max-w-full my-auto sm:mt-24 md:my-8 ">
+    <div class="xl:max-w-[1480px] mx-auto px-4 xl:px-8 flex flex-col sm:flex-row content-start items-stretch">
+        <h2 class="min-w-max sm:w-64 sm:min-w-[16rem] sm:max-w-[16rem] sm:mr-4 p-4 bg-slate-700 text-white break-words">What is the foundation</h2>
 
-		<div class="mt-4 sm:pl-12 sm:pr-12">
-			<p>
-				The <strong>PHP Foundation</strong> is a collective established with the
-				non-profit mission to support, advance, and develop the PHP
-				language. We are a community of PHP veterans, community
-				leaders, and technology companies that rely on PHP as a
-				critical digital infrastructure. We collaborate to ensure
-				PHP language long-term success and maintenance.
-			</p>
+        <div class="mt-4 sm:pl-12 sm:pr-12">
+            <p>
+                The <strong>PHP Foundation</strong> is a collective established with the
+                non-profit mission to support, advance, and develop the PHP
+                language. We are a community of PHP veterans, community
+                leaders, and technology companies that rely on PHP as a
+                critical digital infrastructure. We collaborate to ensure
+                PHP language long-term success and maintenance.
+            </p>
 
-			<p>
-				People and businesses may come and go, so it is vital to
-				ensure that the PHP source code will survive beyond the
-				current contributor base. We wish to contribute to the
-				creation and maintenance of a stable language for
-				generations to come.
-			</p>
+            <p>
+                People and businesses may come and go, so it is vital to
+                ensure that the PHP source code will survive beyond the
+                current contributor base. We wish to contribute to the
+                creation and maintenance of a stable language for
+                generations to come.
+            </p>
 
-			<p>
-				The formation of the PHP Foundation was announced in
-				November 2021 and the PHP Foundation initiative runs with
-				the administration whose goal is to find such an
-				organization structure that will ensure a long-term
-				sustainability of the PHP language development.
-			</p>
-		</div>
-	</div>
+            <p>
+                The formation of the PHP Foundation was announced in
+                November 2021 and the PHP Foundation initiative runs with
+                the administration whose goal is to find such an
+                organization structure that will ensure a long-term
+                sustainability of the PHP language development.
+            </p>
+        </div>
+    </div>
 </section>
 
-<section class="bg-white box-border max-w-full">
-	<div class="m-auto max-w-7xl px-4 xl:px-8 md:my-8 flex flex-col sm:flex-row content-start items-stretch">
-		<h2 class="w-full sm:mr-4 bg-slate-700 text-white p-4 w-64">Governance</h2>
+<section class="max-w-full my-0 py-8 bg-white">
+    <div class="xl:max-w-[1480px] mx-auto px-4 xl:px-8  flex flex-col sm:flex-row content-start items-stretch">
+        <h2 class="min-w-max sm:w-64 sm:min-w-[16rem] sm:mr-4 p-4 bg-slate-700 text-white">Governance</h2>
 
-		<div class="mt-4 sm:pl-12 sm:pr-12">
-			<p>
-				The current group collective administration focuses on maintaining the
-				continuity of the PHP project, in particular on hiring, supporting, and
-				guiding PHP project developers. The Administration also encourages
-				other Financial Contributors and explores strategic partnerships and
-				needs for the PHP project.
-			</p>
+        <div class="mt-4 sm:pl-12 sm:pr-12">
+            <p>
+                The current group collective administration focuses on maintaining the
+                continuity of the PHP project, in particular on hiring, supporting, and
+                guiding PHP project developers. The Administration also encourages
+                other Financial Contributors and explores strategic partnerships and
+                needs for the PHP project.
+            </p>
 
-			<p>
-				The Administrator consists of veteran PHP core developers, PHP
-				community leaders, representatives of the founding companies, and other
-				key stakeholders. In 2022, this is an invitation-only group, while
-				we’re working to get our processes solidified.
-			</p>
+            <p>
+                The Administrator consists of veteran PHP core developers, PHP
+                community leaders, representatives of the founding companies, and other
+                key stakeholders. In 2022, this is an invitation-only group, while
+                we’re working to get our processes solidified.
+            </p>
 
-			<p>
-				To promote transparency, we operate as <a href="https://opencollective.com/phpfoundation">a collective on the Open
-				Collective platform</a>,
-				through which we ensure certain activities, such as selection and
-				financing of PHP core developers contributing to the development of the
-				PHP language. The decisions about these activities are taken by
-				consensus by the administration members, which meet regularly, and are
-				executed by the collective administrators.
-			</p>
+            <p>
+                To promote transparency, we operate as <a href="https://opencollective.com/phpfoundation">a collective on the Open
+                Collective platform</a>,
+                through which we ensure certain activities, such as selection and
+                financing of PHP core developers contributing to the development of the
+                PHP language. The decisions about these activities are taken by
+                consensus by the administration members, which meet regularly, and are
+                executed by the collective administrators.
+            </p>
 
-			<p>
-				All administration members of the PHP Foundation as well as
-				contributors and PHP developers are expected to abide by the <a href="code_of_conduct">Code of
-				Conduct</a>
-				and follow our collective expectations guidelines and <a href="https://opencollective.com/tos">Terms of
-				Service</a> of the platform operated by
-				Open Collective Inc.
-			</p>
-		</div>
-	</div>
+            <p>
+                All administration members of the PHP Foundation as well as
+                contributors and PHP developers are expected to abide by the <a href="code_of_conduct">Code of
+                Conduct</a>
+                and follow our collective expectations guidelines and <a href="https://opencollective.com/tos">Terms of
+                Service</a> of the platform operated by
+                Open Collective Inc.
+            </p>
+        </div>
+    </div>
 </section>
 
-<section class="bg-sky-200 box-border max-w-full">
-	<div class="m-auto max-w-7xl px-4 xl:px-8 md:my-8 flex flex-col sm:flex-row content-start items-stretch">
-        <h2 class="w-full sm:ml-4 bg-sky-700 text-white p-4 w-64">Foundation Activities</h2>
+<section class="max-w-full my-0 py-8 bg-sky-200">
+    <div class="xl:max-w-[1480px] mx-auto px-4 xl:px-8 flex flex-col sm:flex-row content-start items-stretch">
+        <h2 class="min-w-max sm:w-64 sm:min-w-[16rem] sm:max-w-[16rem] sm:mr-4 p-4 bg-sky-700 text-white">Foundation Activities</h2>
 
         <div class="mt-4 sm:pl-12 sm:pr-12">
             <p>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,12 +2,18 @@ module.exports = {
   content: ["./source/**/*.html"],
   theme: {
     extend: {
+      backgroundSize: {
+        'horizontal': 'auto 0',
+      },
       colors: {
         'foundation': 'rgba(25, 25, 28, .3)',
         'baseblack': '#19191c',
         'fbg': 'rgba(25, 25, 28, .1)',
         'hborder': 'rgba(39, 40, 44, .2)',
       },
+      transitionProperty: {
+        'footer': 'background-size, color',
+      }
     },
 
     screens: {


### PR DESCRIPTION
This patch accomplishes two things:

- It cleans up the CSS in a number of ways:
  - It removes unused style definitions.
  - It moves most CSS definitions into either the base or components Tailwind layers, and updates them to use `@apply`, giving better consistency.
  - It simplifies markup and tailwind class definitions where possible to better and more simply achieve the desired layout.
- It makes the site, and particularly the home page and the site footer, more mobile friendly. In particular, the two-column layout becomes a single column, with headers stretching across the screen width, on small devices. additionally, the "header" column is now consistently sized across all horizontal bands.
