### PR TITLE
Add tags support

### DIFF
--- a/app/src/Blog/Tag.php
+++ b/app/src/Blog/Tag.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Blog;
+
+class Tag
+{
+    public const ALLOWED_TAGS = [
+        'interview' => 'Interview',
+        'roundup' => 'PHP Roundup',
+        'update' => 'The PHP Foundation Update',
+    ];
+}

--- a/source/_posts/2022-04-28-php-roundup-1.md
+++ b/source/_posts/2022-04-28-php-roundup-1.md
@@ -2,7 +2,7 @@
 title: 'PHP Roundup #1'
 layout: post
 tags:
-    - update
+    - roundup
 author:
   name: Ayesh Karunaratne
   url: https://twitter.com/Ayeshlive

--- a/source/_posts/2022-05-30-php-core-roundup-2.md
+++ b/source/_posts/2022-05-30-php-core-roundup-2.md
@@ -3,7 +3,7 @@
 title: 'PHP Core Roundup #2'
 layout: post
 tags:
-    - update
+    - roundup
 author:
   name: Ayesh Karunaratne
   url: https://aye.sh

--- a/source/_posts/2022-06-30-php-core-roundup-3.md
+++ b/source/_posts/2022-06-30-php-core-roundup-3.md
@@ -3,7 +3,7 @@
 title: 'PHP Core Roundup #3'
 layout: post
 tags:
-    - update
+    - roundup
 author:
   name: Ayesh Karunaratne
   url: https://aye.sh

--- a/source/_views/post.html
+++ b/source/_views/post.html
@@ -16,6 +16,16 @@
 				by <a href="{{ page.author.url }}">{{ page.author.name }}</a>
             </div>
             {% endif %}
+
+            {% if page.tags is defined%}
+            <div class="mt-3 space-x-1">
+                {% for tag in page.tags %}
+                <a href="{{ site.url }}/blog/tag/{{ tag|url_encode(true) }}" class="bg-[#7f52ff] hover:bg-[rgba(127,82,255,.8)] text-white px-2 py-1 rounded no-underline text-sm">
+                    {{ constant('App\\Blog\\Tag::ALLOWED_TAGS')[tag] ?? tag }}
+                </a>
+                {% endfor %}
+            </div>
+            {% endif %}
         </header>
 
         <section class="main_body">

--- a/source/blog/tag/tag.html
+++ b/source/blog/tag/tag.html
@@ -1,41 +1,27 @@
 ---
-title: Blog
 layout: default
-permalink: blog
-generator: pagination
+title: Tag Archive
+generator: [posts_tag_index, pagination]
 pagination:
-    max_per_page: 100
-use:
-    - posts
+    provider: page.tag_posts
 ---
 
 <main class="flex flex-row justify-center min-w-[320px] min-h-[100vh] w-full pt-4">
-	<section class="max-w-2xl w-full bg-white px-4 md:px-0">
-		<header class="mb-16">
-            <h1>{{ page.title }}</h1>
+    <section class="max-w-2xl w-full bg-white px-4 md:px-0">
+        <header class="mb-16">
+            <h1>Tag: {{ constant('App\\Blog\\Tag::ALLOWED_TAGS')[page.tag] ?? page.tag }}</h1>
         </header>
 
         {% for post in page.pagination.items %}
         <section class="mb-4">
             <header>
                 <h4 class="mb-1"><a href="{{ site.url }}{{ post.url }}">{{ post.title|raw }}</a></h4>
-				{% if post.author is defined%}
-				<div class="text-xs mb-2">
-					Published on <span>{{ post.published_at|date("M d, Y") }}</span>
-					by <a href="{{ post.author.url }}">{{ post.author.name }}</a>
-				</div>
-				{% endif %}
-
-                {% if post.tags is defined%}
-                <div class="mb-4 space-x-1">
-                    {% for tag in post.tags %}
-                    <a href="{{ site.url }}/blog/tag/{{ tag|url_encode(true) }}" class="bg-[#7f52ff] hover:bg-[rgba(127,82,255,.8)] text-white px-2 py-1 rounded no-underline text-sm">
-                        {{ constant('App\\Blog\\Tag::ALLOWED_TAGS')[tag] ?? tag }}
-                    </a>
-                    {% endfor %}
+                {% if post.author is defined%}
+                <div class="text-xs mb-4">
+                    Published on <span>{{ post.published_at|date("M d, Y") }}</span>
+                    by <a href="{{ post.author.url }}">{{ post.author.name }}</a>
                 </div>
                 {% endif %}
-
                 <p class="text-base">{{ post.content|striptags|length > 100 ? (post.content|striptags|slice(0, 150) ~ '...')|raw : post.content|striptags|raw }}</p>
             </header>
         </section>
@@ -49,7 +35,7 @@ use:
                 <div class="font-bold text-blue-500">Older Posts</div>
             </a>
             {% endif %}
-
+            
             {% if page.pagination.previous_page %}
             <a href="{{ site.url }}{{ page.pagination.previous_page.url }}" class="flex flex-col w-1/2 border p-2 mx-2 rounded hover:border-[#7f52ff] transition-all no-underline">
                 <div class="mb-1 text-sm text-gray-600 font-medium">Next</div>


### PR DESCRIPTION
Tags are indicated in the posts, but not used in any way =)

What do you think?

Aside: URLs in that case are not very pretty, perhaps it's better to make an array of used tags, where the key is the code of the tag used in the URL, and the value is a nice title, e.g.

```
$tags = ['update' => 'PHP Foundation Update', ...]
```

<details>
  <summary>Demo</summary>
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/4685504/166948834-24238bff-b7b3-4ae9-bb30-4461ffbbe5aa.png">
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/4685504/166948935-87b6ce03-dd2c-4bef-83c2-5b559cddfd56.png">
<img width="1679" alt="image" src="https://user-images.githubusercontent.com/4685504/166948983-b7261f4d-5146-4de3-9c23-e6226f671360.png">

</details>
