### PR TITLE
Add `prod` configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /.sculpin/
 /app/cache/*
 /app/config/sculpin_kernel_*.yml
-/app/config/sculpin_site_*.yml
 /app/logs/*
 /output_*/
 /node_modules/

--- a/app/config/sculpin_site_prod.yml
+++ b/app/config/sculpin_site_prod.yml
@@ -1,0 +1,3 @@
+title: The PHP Foundation
+subtitle: Supporting, Advancing, and Developing the PHP Language
+url: https://thephp.foundation


### PR DESCRIPTION
Relates https://github.com/ThePHPF/thephp.foundation/pull/30#issuecomment-1118562284

--

The production environment uses relative URLs when they are expected to have an absolute path.
For example, the sharing image for social networks won't load because the validator doesn't understand the relative URL.

In the templates, instead of `{{ site.url }}` the `https://thephp.foundation` will be substituted
in the production environment, for dev environment, all URLs will still be relative