### PR TITLE
Correctly render HTML special chars on blog overview

### DIFF
--- a/source/blog.html
+++ b/source/blog.html
@@ -26,7 +26,7 @@ use:
 
 				</div>
 				{% endif %}
-				<p class="text-base">{{ post.content|striptags | length > 100 ? post.content|striptags|slice(0, 150) ~ '...' : post.content|striptags }}</p>
+				<p class="text-base">{{ post.content|striptags|length > 100 ? (post.content|striptags|slice(0, 150) ~ '...')|raw : post.content|striptags|raw }}</p>
             </header>
         </section>
         {% endfor %}


### PR DESCRIPTION
This will add the twig raw filter to correctly render special characters such as `<`.

Without it looks like this:
![image](https://user-images.githubusercontent.com/5249624/177058668-781a89a3-c855-472c-be13-9a7d42705881.png)

After the change:
![image](https://user-images.githubusercontent.com/5249624/177058683-f51891be-ce42-4d36-b42a-6908fca0fe81.png)
