### PR TITLE
Fix footer element padding

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -146,6 +146,10 @@
     background-size: auto calc(100% + 4px);
 }
 
+footer > ul, footer > p {
+    padding: 0;
+}
+
 code {
     font-family: Consolas, "PT Mono", "Liberation Mono", Courier, monospace;
     line-height: normal;


### PR DESCRIPTION
Fixes GH-56
Set `padding: 0` to footer elements to prevent them from inheriting standard padding-bottom appearance. This makes the footer items flushed and vertically centered, as well as keeping the size of hover paint area the same as text size.

![image](https://user-images.githubusercontent.com/811553/192860117-88e08b5d-e2ea-44fd-be5e-8f396e013b13.png)
