### PR TITLE
Add PrestaShop to the founding companies

### DIFF
--- a/source/_posts/2022-11-22-transparency-and-impact-report-2022.md
+++ b/source/_posts/2022-11-22-transparency-and-impact-report-2022.md
@@ -53,6 +53,7 @@ Initial members:
 * Laravel
 * Zend by Perforce
 * Symfony
+* PrestaShop
 
 Representatives of these companies formed the initial administration group.
 


### PR DESCRIPTION
PrestaShop was on the initial list of founding companies https://blog.jetbrains.com/phpstorm/2021/11/the-php-foundation/#the_php_foundation. However, due to an error on the OpenCollective side, their 10k contribution got lost. We've just discovered this unfortunate mistake, so I'm fixing the list in the report.