### PR TITLE
Allow to specify multiple authors for blog posts

### DIFF
--- a/app/src/Bundles/AtomFeedGeneratorBundle/AtomFeedGenerator.php
+++ b/app/src/Bundles/AtomFeedGeneratorBundle/AtomFeedGenerator.php
@@ -33,8 +33,6 @@ class AtomFeedGenerator implements EventSubscriberInterface
 
         $env = $this->configuration->get('env') ?? 'dev';
 
-        $baseUrl = $this->configuration->get('url') ?? 'http://localhost';
-
         $filesystem = new Filesystem();
         if (!$filesystem->exists("output_$env/rss/")) {
             $filesystem->mkdir("output_$env/rss/");
@@ -48,31 +46,49 @@ class AtomFeedGenerator implements EventSubscriberInterface
                 continue;
             }
 
+            $data = $source->data();
+
             if ($source->file()->getExtension() !== 'md') {
                 continue;
             }
 
-            if (!$source->data()->get('author')) {
+            if (!$data->get('author')) {
                 continue;
             }
 
-            if ($data = $source->data()) {
-                $slug = mb_strtolower(preg_replace('/\W/', '_', $data->get('author.name')));
-
-                $post = new Entry();
-
-                $post->title = $data->get('title');
-                $post->link = $baseUrl.$data->get('url');
-                $post->author = $data->get('author.name');
-                $post->authorURL = $data->get('author.url');
-                $post->description = $data->get('blocks.content');
-                $post->published_at = new \DateTimeImmutable($data->get('published_at'));
-
-                $entries["output_$env/rss/$slug.xml"][] = $post;
+            if ($name = $data->get('author.name')) {
+                $slug = $this->slug($name);
+                $entries["output_$env/rss/$slug.xml"][] = $this->fetchEntry($data, $data->get('author'));
+            } else {
+                foreach ($data->get('author') as $author) {
+                    $slug = $this->slug($author['name']);
+                    $entries["output_$env/rss/$slug.xml"][] = $this->fetchEntry($data, $author);
+                }
             }
         }
 
         $this->generateFeed($entries);
+    }
+
+    protected function fetchEntry(Configuration $data, $author): Entry
+    {
+        $baseUrl = $this->configuration->get('url') ?? 'http://localhost';
+
+        $post = new Entry();
+
+        $post->title = $data->get('title');
+        $post->link = $baseUrl . $data->get('url');
+        $post->author = $author['name'];
+        $post->authorURL = $author['url'];
+        $post->description = $data->get('blocks.content');
+        $post->published_at = new \DateTimeImmutable($data->get('published_at'));
+
+        return $post;
+    }
+
+    protected function slug($author): string
+    {
+        return mb_strtolower(preg_replace('/\W/', '_', $author));
     }
 
     protected function generateFeed(array $entries = []): void

--- a/app/src/Bundles/SharingImageGeneratorBundle/SharingImageGenerator.php
+++ b/app/src/Bundles/SharingImageGeneratorBundle/SharingImageGenerator.php
@@ -46,19 +46,23 @@ class SharingImageGenerator implements EventSubscriberInterface
                 continue;
             }
 
-            if (!$source->data()->get('title')) {
+            $data = $source->data();
+
+            if (!$data->get('title')) {
                 continue;
             }
 
             $filename = str_replace('.md', '.png', $source->file()->getFilename());
 
             $image = new \App\Seo\SharingImageGenerator();
-            if ($title = $source->data()->get('title')) {
+            if ($title = $data->get('title')) {
                 $image->setTitle($title);
             }
 
-            if ($author = $source->data()->get('author.name')) {
-                $image->setAuthor("by $author");
+            if ($name = $data->get('author.name')) {
+                $image->setAuthor("by $name");
+            } elseif (!empty($data->get('author'))) {
+                $image->setAuthor('by ' . implode(', ', array_column($data->get('author'), 'name')));
             }
 
             $image->save("output_$env/assets/share/$filename");

--- a/app/src/Sitemap/Author.php
+++ b/app/src/Sitemap/Author.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Sitemap;
+
+class Author
+{
+    public function __construct($name, $url)
+    {
+        $this->name = $name;
+        $this->url = $url;
+    }
+
+    public string $name;
+
+    public string $url;
+}

--- a/app/src/Sitemap/Entry.php
+++ b/app/src/Sitemap/Entry.php
@@ -8,11 +8,10 @@ class Entry
 
     public string $link;
 
-    public string $author;
-
-    public string $authorURL;
+    /** @var Author[] */
+    public array $authors = [];
 
     public string $description;
-    
+
     public \DateTimeImmutable $published_at;
 }

--- a/app/src/Sitemap/SitemapGenerator.php
+++ b/app/src/Sitemap/SitemapGenerator.php
@@ -49,13 +49,17 @@ class SitemapGenerator
 
             $id = $dom->createElement('id', $entry->link);
 
-            $author = $dom->createElement('author');
-            $author->appendChild($dom->createElement('name', $entry->author));
-            $author->appendChild($dom->createElement('uri', $entry->authorURL));
+            foreach ($entry->authors as $authorEntity) {
+                $author = $dom->createElement('author');
+                $author->appendChild($dom->createElement('name', $authorEntity->name));
+                $author->appendChild($dom->createElement('uri', $authorEntity->url));
+
+                $element->append($author);
+            }
 
             $updated = $dom->createElement('updated', $entry->published_at->format(DATE_RSS));
-            
-            $element->append($title, $content, $link, $id, $updated, $author);
+
+            $element->append($title, $content, $link, $id, $updated);
 
             $feed->append($element);
         }

--- a/source/_posts/2023-07-01-php-core-roundup-14.md
+++ b/source/_posts/2023-07-01-php-core-roundup-14.md
@@ -4,8 +4,11 @@ layout: post
 tags:
   - roundup
 author:
-  name: Ayesh Karunaratne
-  url: https://aye.sh
+  - name: Ayesh Karunaratne
+    url: https://aye.sh
+  
+  - name: Sergey Panteleev
+    url: https://sergeypanteleev.com
 published_at: 29 June 2023
 
 ---

--- a/source/_views/post.html
+++ b/source/_views/post.html
@@ -6,10 +6,18 @@
         <header class="mb-8">
             <h1 class="">{{ page.title }}</h1>
 
-            {% if page.author is defined%}
+            {% if page.author.name is defined%}
             <div class="text-xs">
 				Published on <span>{{ page.published_at|date("M d, Y") }}</span>
 				by <a href="{{ page.author.url }}">{{ page.author.name }}</a>
+            </div>
+            {% elseif page.author is iterable%}
+            <div class="text-xs">
+                Published on <span>{{ page.published_at|date("M d, Y") }}</span>
+                by
+                {% for author in page.author %}
+                <a href="{{ author.url }}">{{ author.name }}</a>{% if loop.last == false  %}, {% endif %}
+                {% endfor %}
             </div>
             {% endif %}
 

--- a/source/blog.html
+++ b/source/blog.html
@@ -19,12 +19,20 @@ use:
         <section class="mb-4">
             <header>
                 <h4 class="mb-1"><a href="{{ site.url }}{{ post.url }}">{{ post.title|raw }}</a></h4>
-				{% if post.author is defined%}
+				{% if post.author.name is defined%}
 				<div class="text-xs mb-2">
 					Published on <span>{{ post.published_at|date("M d, Y") }}</span>
 					by <a href="{{ post.author.url }}">{{ post.author.name }}</a>
 				</div>
-				{% endif %}
+                {% elseif post.author is iterable%}
+                <div class="text-xs mb-2">
+                    Published on <span>{{ post.published_at|date("M d, Y") }}</span>
+                    by
+                    {% for author in post.author %}
+                    <a href="{{ author.url }}">{{ author.name }}</a>{% if loop.last == false  %}, {% endif %}
+                    {% endfor %}
+                </div>
+                {% endif %}
 
                 {% if post.tags is defined%}
                 <div class="mb-4 space-x-1">

--- a/source/blog/tag/tag.html
+++ b/source/blog/tag/tag.html
@@ -20,10 +20,18 @@ pagination:
         <section class="mb-4">
             <header>
                 <h4 class="mb-1"><a href="{{ site.url }}{{ post.url }}">{{ post.title|raw }}</a></h4>
-                {% if post.author is defined%}
+                {% if post.author.name is defined%}
                 <div class="text-xs mb-4">
                     Published on <span>{{ post.published_at|date("M d, Y") }}</span>
                     by <a href="{{ post.author.url }}">{{ post.author.name }}</a>
+                </div>
+                {% elseif post.author is iterable%}
+                <div class="text-xs mb-4">
+                    Published on <span>{{ post.published_at|date("M d, Y") }}</span>
+                    by
+                    {% for author in post.author %}
+                    <a href="{{ author.url }}">{{ author.name }}</a>{% if loop.last == false  %}, {% endif %}
+                    {% endfor %}
                 </div>
                 {% endif %}
                 <p class="text-base">{{ post.content|striptags|length > 100 ? (post.content|striptags|slice(0, 150) ~ '...')|raw : post.content|striptags|raw }}</p>


### PR DESCRIPTION
- [x] Generate RSS feed for each author
- [x] Update sharing image
- [x] Update blog post index pages (blog, tag)
- [x] Update blog post detail page

PHP Core Roundup 14 updated for example:

- Sharing image with multiple authors:
https://deploy-pr-93--thephpfoundation.netlify.app/assets/share/2023-07-01-php-core-roundup-14.png
- My and Ayesh's RSS feed contains roundup 14:
https://deploy-pr-93--thephpfoundation.netlify.app/rss/ayesh_karunaratne.xml
https://deploy-pr-93--thephpfoundation.netlify.app/rss/sergey_panteleev.xml

Fix #92