### PR TITLE
Rename "Administration" to "Board"

### DIFF
--- a/source/structure.html
+++ b/source/structure.html
@@ -9,12 +9,12 @@ permalink: structure
         <h1 class="text-4xl font-bold">{{ page.title }}</h1>
     </header>
 
-    <div class="my-16">
+    <div class="my-16  mb-24">
         <div class="grid grid-cols-1 gap-12 lg:grid-cols-3 lg:gap-8">
             <div class="space-y-5 sm:space-y-4">
-                <h2 class="text-3xl text-gray-800 font-bold tracking-tight" id="admins">Administration</h2>
+                <h2 class="text-3xl text-gray-800 font-bold tracking-tight mt-0" id="admins">Board</h2>
                 <div class="text-xl text-gray-500">
-                    The Administration consists of veteran PHP core developers, PHP community leaders,
+                    The Board consists of veteran PHP core developers, PHP community leaders,
                     representatives of the founding companies, and other key stakeholders.
                 </div>
             </div>
@@ -23,7 +23,7 @@ permalink: structure
                     {{ include('structure-item.html', {
                         name: 'Sebastian Bergmann',
                         image: 'https://avatars.githubusercontent.com/u/25218?s=200&v=4',
-                        job: 'Administration',
+                        job: 'Board member',
                         mastodon: 'https://phpc.social/@sebastian',
                         github: 'https://github.com/sebastianbergmann',
                     }) }}
@@ -31,7 +31,7 @@ permalink: structure
                     {{ include('structure-item.html', {
                         name: 'Joe Watkins',
                         image: 'https://avatars.githubusercontent.com/u/2236138?s=200&v=4',
-                        job: 'Administration',
+                        job: 'Board member',
                         twitter: 'https://twitter.com/krakjoe',
                         github: 'https://github.com/krakjoe',
                     }) }}
@@ -39,7 +39,7 @@ permalink: structure
                     {{ include('structure-item.html', {
                         name: 'Nils Adermann',
                         image: 'https://avatars.githubusercontent.com/u/154844?s=200&v=4',
-                        job: 'Administration',
+                        job: 'Board member',
                         twitter: 'https://twitter.com/naderman',
                         github: 'https://github.com/naderman',
                     }) }}
@@ -47,7 +47,7 @@ permalink: structure
                     {{ include('structure-item.html', {
                         name: 'Benjamin Eberlei',
                         image: 'https://avatars.githubusercontent.com/u/26936?s=200&v=4',
-                        job: 'Administration',
+                        job: 'Board member',
                         twitter: 'https://twitter.com/beberlei',
                         github: 'https://github.com/beberlei',
                     }) }}
@@ -55,14 +55,14 @@ permalink: structure
                     {{ include('structure-item.html', {
                         name: 'Josepha Haden',
                         image: 'https://2.gravatar.com/avatar/b1384df9e94641211dd00e4e8203d80c?s=200',
-                        job: 'Administration',
+                        job: 'Board member',
                         twitter: 'https://twitter.com/JosephaHaden',
                     }) }}
 
                     {{ include('structure-item.html', {
                         name: 'Roman Pronskiy',
                         image: 'https://avatars.githubusercontent.com/u/1196825?s=200&v=4',
-                        job: 'Administration',
+                        job: 'Board member, Operations manager',
                         twitter: 'https://twitter.com/pronskiy',
                         github: 'https://github.com/pronskiy',
                     }) }}
@@ -70,7 +70,7 @@ permalink: structure
                     {{ include('structure-item.html', {
                         name: 'Nicolas Grekas',
                         image: 'https://avatars.githubusercontent.com/u/243674?s=200&v=4',
-                        job: 'Administration',
+                        job: 'Board member',
                         twitter: 'https://twitter.com/nicolasgrekas',
                         github: 'https://github.com/nicolas-grekas/',
                     }) }}
@@ -78,7 +78,7 @@ permalink: structure
                     {{ include('structure-item.html', {
                         name: 'Sara Golemon',
                         image: 'https://avatars.githubusercontent.com/u/812538?s=200&v=4',
-                        job: 'Administration',
+                        job: 'Board member',
                         mastodon: 'https://phpc.social/@pollita',
                         github: 'https://github.com/sgolemon',
                     }) }}
@@ -86,7 +86,7 @@ permalink: structure
                     {{ include('structure-item.html', {
                         name: 'Nikita Popov',
                         image: 'https://avatars.githubusercontent.com/u/216080?s=200&v=4',
-                        job: 'Administration',
+                        job: 'Board member',
                         twitter: 'https://twitter.com/nikita_ppv',
                         github: 'https://github.com/nikic',
                     }) }}
@@ -94,7 +94,7 @@ permalink: structure
                     {{ include('structure-item.html', {
                         name: 'Matthew Weier O\'Phinney',
                         image: 'https://avatars.githubusercontent.com/u/25943?s=200&v=4',
-                        job: 'Administration',
+                        job: 'Board member',
                         mastodon: 'https://phpc.social/@mwop',
                         github: 'https://github.com/weierophinney',
                     }) }}
@@ -103,10 +103,10 @@ permalink: structure
         </div>
     </div>
 
-    <div class="my-16">
+    <div class="my-16 mb-24">
         <div class="grid grid-cols-1 gap-12 lg:grid-cols-3 lg:gap-8">
             <div class="space-y-5 sm:space-y-4">
-                <h2 class="text-3xl text-gray-800 font-bold tracking-tight" id="core_developers">Core Developers</h2>
+                <h2 class="text-3xl text-gray-800 font-bold tracking-tight mt-0" id="core_developers">Core Developers</h2>
                 <div class="text-xl text-gray-500">
                     Core Developers are sponsored by the PHP Foundation and develop the Core of PHP on a part-time
                     or full-time basis.
@@ -168,7 +168,7 @@ permalink: structure
     <div class="my-16">
         <div class="grid grid-cols-1 gap-12 lg:grid-cols-3 lg:gap-8">
             <div class="space-y-5 sm:space-y-4">
-                <h2 class="text-3xl text-gray-800 font-bold tracking-tight" id="community">Community</h2>
+                <h2 class="text-3xl text-gray-800 font-bold tracking-tight mt-0" id="community">Community</h2>
                 <div class="text-xl text-gray-500">
                     Active community members who help the PHP Foundation.
                 </div>


### PR DESCRIPTION
Initially, we referred to it as the admin group; however, this terminology can be confusing for those who are not familiar with the PHP Foundation's background.

Furthermore, when delivering talks or communicating with external parties, describing one's title as "PHP Foundation Administrator" can create a misleading impression, as the term is often used differently in the industry.

Additionally, I have added "Operations Manager" to my title because JetBrains currently sponsors me to work on the foundation almost full-time, and I'm handling any inquiries that come to the foundation.