### PR TITLE
state of generics post: typo in erased generic type declarations example

### DIFF
--- a/source/_posts/2024-08-19-state-of-generics-and-collections.md
+++ b/source/_posts/2024-08-19-state-of-generics-and-collections.md
@@ -296,7 +296,7 @@ Here is what the same Dict class as above would look like:
 		}
 	}
 
-	function f(Dict<Key,Value> $dict) {}
+	function f(Dict<string,string> $dict) {}
 
 	$dict = new Dict([1 => 'foo']);
 	$dict->set("foo", "bar"); // Static analyser error


### PR DESCRIPTION
I think there is an error in the code example for **Erased Generic Type Declaration**

In the function signature, the type hints need to be actual types `<string,string>` not 'template' names `<Key,Value>`