### PR TITLE
CI: Update peaceiris/actions-gh-pages GitHub Action to v4

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -38,7 +38,7 @@ jobs:
       run: ./vendor/bin/sculpin generate --env=prod
 
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       if: ${{ github.ref == 'refs/heads/main' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`peaceiris/actions-gh-pages` action uses actions/checkout@v3, which in turn uses Node 16. Node 16 is deprecated on GitHub actions.

This updates to the latest version of this action, which uses the latest actions/checkout@v4 and avoids Node 16 notices.