### PR TITLE
Add Passbolt as Silver sponsor

### DIFF
--- a/app/src/Bundles/PhpFoundationBundle/Extensions/PhpFoundation.php
+++ b/app/src/Bundles/PhpFoundationBundle/Extensions/PhpFoundation.php
@@ -59,6 +59,7 @@ class PhpFoundation extends AbstractExtension
                     'sentry-team' => 'Sentry Team',
                     'cybozu' => 'Cybozu',
                     'manychat' => 'Manychat',
+                    'passbolt' => 'Passbolt',
                 ],
             'Gold' =>
                 [


### PR DESCRIPTION
CI has been crashing a lot lately, when requesting https://opencollective.com/phpfoundation/members/organizations.json.

What do you think, so that we could just make the block with sponsor-organizations an array by itself, without relying on a query in opencollective?

Basically, we only use the logo and link from opencollective (and that sometimes replaced by others), so a regular array wouldn't add much manual work.

just something like that:
```php
'Silver' => [
    [
        'title' => 'Company Name',
        'url' => 'https://website.com',
        'logo' => '/path/to/img.png',
    ],
    ...
]
```

If you don't mind, I'll get on it.