### PR TITLE
Update the link to the Quarkslab blog

### DIFF
--- a/source/_posts/2025-04-10-php-core-security-audit-results.md
+++ b/source/_posts/2025-04-10-php-core-security-audit-results.md
@@ -70,7 +70,7 @@ This audit underscores our commitment to enhancing PHP’s security and reliabil
 
 * [Audit Report](/assets/files/24-07-1730-REP-V1.4_temp.pdf)
 * [OSTIF Blog](https://ostif.org/php-audit-complete/)
-* [Quarkslab Blog](https://blog.quarkslab.com/)
+* [Quarkslab Blog](https://blog.quarkslab.com/security-audit-of-php-src.html)
 
 If your company is interested in commissioning another round of security audit, please contact The PHP Foundation team: [contact@thephp.foundation](mailto:contact@thephp.foundation).
 


### PR DESCRIPTION
Instead of linking to the homepage of the blog, this links directly to the post about the PHP security audit.