### PR TITLE
Remove incorrect note for CVE-2024-8928

### DIFF
--- a/source/_posts/2025-04-10-php-core-security-audit-results.md
+++ b/source/_posts/2025-04-10-php-core-security-audit-results.md
@@ -42,7 +42,6 @@ Notably, four vulnerabilities received CVE identifiers:
 
 * CVE-2024-9026: Log tampering vulnerability in PHP-FPM, allowing potential manipulation or removal of characters from log messages.
 * CVE-2024-8925: Flaw in PHP’s multipart form data parsing, potentially leading to data misinterpretation.
-* CVE-2024-8928: Memory-related vulnerability in PHP’s filter handling, leading to segmentation faults.
 * CVE-2024-8929: Issue where a malicious MySQL server could cause the client to disclose heap content from other SQL requests.
 
 ## Recommendations and Resolutions


### PR DESCRIPTION
This was a mix up in the description that was copied from OSTIF document which took description from another issue:

A memory-related vulnerability in PHP's filter handling system, particularly when processing input with convert.quoted-printable-decode filters, leads to a segmentation fault. This vulnerability is triggered through specific sequences of input data, causing PHP to crash. When exploited, it allows an attacker to extract a single byte of data from the heap or cause a DoS. (CVE-2024-11233)

This is taken from ALAS advisory:
https://alas.aws.amazon.com/AL2023/ALAS-2025-845.html

It clearly shows that it is a mix up with CVE-2024-11233. The CVE-2024-8928 is a different issue though.