### PR TITLE
Correct example code

### DIFF
--- a/source/_posts/2025-08-05-compile-generics.md
+++ b/source/_posts/2025-08-05-compile-generics.md
@@ -213,7 +213,7 @@ class Articles extends Sequence<Article> {}
 
 class Library extends Set<Book> {}
 
-class YearBooks<int, Book> {}
+class YearBooks extends Dict<int, Bool> {}
 ```
 
 Those concrete classes could have additional methods in them if desired, but that's optional.  The above would be sufficient to have a collection that mapped integers to Book objects, and had syntax-level guarantees those types would hold.


### PR DESCRIPTION
Typo we didn't catch, just fixing it.  (Bob found it in Slack.)