### PR TITLE
Fix broken php-src GitHub link in blog post

### DIFF
--- a/source/_posts/2025-09-30-application-form-2026.md
+++ b/source/_posts/2025-09-30-application-form-2026.md
@@ -34,7 +34,7 @@ The development of <a href="https://github.com/php/php-src">the PHP core</a> is 
 
 As before, we require experience in PHP core development. Ideally, you should have all, but at least some of the following:
 
-- Pull-requests / commits to [php/php-src](https://github.com/php/php-src/️)
+- Pull-requests / commits to [php/php-src](https://github.com/php/php-src)
 - Experience in writing PHP extensions
 - Participation in PHP mailing lists
 - Contributions to other open-source projects


### PR DESCRIPTION
This PR fixes a broken link in the blog post.

The php-src repository link had an invisible Unicode variation selector (U+FE0F) at the end of the URL, which caused it to render as:
https://github.com/php/php-src/%EF%B8%8F

I removed the stray character so the link now correctly points to:
https://github.com/php/php-src
