### PR TITLE
Clarify wording around the Foundations and PHP's RFC process

### DIFF
--- a/source/_pages/foundation.md
+++ b/source/_pages/foundation.md
@@ -29,8 +29,7 @@ The primary task of the PHP Foundation is to fund developers to work on PHP. Fun
 through the Open Collective platform may be used in the first place to engage the services of
 PHP developers to further advance the development and maintenance of the language.
 
-The current Request for Comments (RFC) is not affiliated to the PHP Foundation, and the language
-decisions are the matter of the PHP Internals community.
+PHP’s Request for Comments (RFC) process operates independently of the PHP Foundation. Decisions regarding the language are made through this community-driven process.
 
 ## Team Timeline
 

--- a/source/_pages/foundation.md
+++ b/source/_pages/foundation.md
@@ -29,7 +29,7 @@ The primary task of the PHP Foundation is to fund developers to work on PHP. Fun
 through the Open Collective platform may be used in the first place to engage the services of
 PHP developers to further advance the development and maintenance of the language.
 
-PHP’s Request for Comments (RFC) process operates independently of the PHP Foundation. Decisions regarding the language are made through this community-driven process.
+PHP’s Request for Comments (RFC) process operates independently of the PHP Foundation. Decisions regarding the language are made through this community-driven process, as outlined [here](https://wiki.php.net/rfc/howto).
 
 ## Team Timeline
 


### PR DESCRIPTION
Two main points I tried to address:

- The "current" in the current wording is overly specific and implies that the process might be changing.
- "PHP Internals Community" is not an established term outside of casual usage the name of the mailing list.

~I Intentionally avoided linking to the RFC document to keep the links on the page focused on foundation matters.~
Edit: As per review feedback, added a link to the RFC document.