### PR TITLE
CI: Update dependencies and runtimes

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.3
+        php-version: '8.5'
         extensions: mbstring, intl, readline
         tools: composer:v2
 

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 24
 
     - name: Install asset deps
       run: npm install

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
     name: Deploy website
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
     steps:
     - name: Checkout
       uses: actions/checkout@main

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -4,7 +4,7 @@ on:
     types: [ opened, synchronize, reopened, labeled ]
 jobs:
   build:
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
     permissions:
       contents: read
       pull-requests: write # Required when require-reapproval=true

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Update Image Version in the related HelmChart values.yaml
         uses: fjogeleit/yaml-update-action@main

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -51,13 +51,13 @@ jobs:
           tools: composer:v2
 
       - name: Install PHP deps
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v4
 
       - name: Build production site
         run: ./vendor/bin/sculpin generate --env=prod
 
       - name: Deploy to Netlify
-        uses: nwtgck/actions-netlify@v1.2
+        uses: nwtgck/actions-netlify@v4.0
         with:
           production-deploy: false
           publish-dir: './output_prod'

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
           extensions: mbstring, intl, readline
           tools: composer:v2
 


### PR DESCRIPTION
 - Use `ubuntu24.04` images instead of Ubuntu 22.
 - Use Node 24 instead of Node 20.
 - Use PHP 8.5 instead of PHP 8.3
 - Update to `ramsey/composer-install@v4` from `@v2`
 - Update to `nwtgck/actions-netlify@v4.0` from `@v1.2`. 
